### PR TITLE
chore: Setup chrome dev on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Archive test videos
         uses: actions/upload-artifact@v2
         with:
-          name: code-coverage-report
-          path: output/test/code-coverage.html
+          name: chrome-test
+          path: cypress/videos/index.spec.ts.mp4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       - run: npm install
       - run: npm run build
-      - run: npm run test
+      - run: npm run test:chrome
       - name: Archive test videos
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,11 @@ jobs:
           node-version: 14.x
 
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v0.0.0
+        uses: browser-actions/setup-chrome@latest
         with:
           # forced-colors emulation is only available on chrome version > 98 for now
-          chromium-version: dev
+          chrome-version: dev
+      - run: chrome --version
 
       - run: npm install
       - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,11 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Setup chrome in CI
-        uses: browser-actions/setup-chrome@latest
-
-      # forced-colors mode is only supported on chromium > 98 for now
-      - name: Install Chrome dev
-        run: chrome --version
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v0.0.0
         with:
-          chrome-version: dev
+          # forced-colors emulation is only available on chrome version > 98 for now
+          chromium-version: dev
 
       - run: npm install
       - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,12 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Setup chrome in CI
+        uses: browser-actions/setup-chrome@latest
+
       # forced-colors mode is only supported on chromium > 98 for now
-      - name: Setup chrome dev
-      - uses: browser-actions/setup-chrome@latest
-      - run: chrome --version
+      - name: Install Chrome dev
+        run: chrome --version
         with:
           chrome-version: dev
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,12 +29,19 @@ jobs:
         uses: actions/setup-node@v2.5.0
         with:
           node-version: 14.x
-          
+
+      # forced-colors mode is only supported on chromium > 98 for now
+      - name: Setup chrome dev
+      - uses: browser-actions/setup-chrome@latest
+      - run: chrome --version
+        with:
+          chrome-version: dev
+
       - run: npm install
       - run: npm run build
       - run: npm run test
-      - name: Archive test video
+      - name: Archive test videos
         uses: actions/upload-artifact@v2
         with:
-          name: test-video
-          path: cypress/videos/index.spec.ts.mp4
+          name: code-coverage-report
+          path: output/test/code-coverage.html

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "files": ["./dist", "./index.d.ts"],
   "scripts": {
     "start": "cypress open",
-    "test": "cypress run",
+    "test": "cypress run --browser chrome:dev",
     "build": "tsc"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "files": ["./dist", "./index.d.ts"],
   "scripts": {
     "start": "cypress open",
-    "test": "cypress run --browser chrome:dev",
+    "test:chrome": "cypress run --browser chrome",
+    "test:edge": "cypress run --browser edge",
     "build": "tsc"
   },
   "author": "",


### PR DESCRIPTION
forced colors emulation is only available on chromium > 98, therefore
use the dev version of chrome for testing for now